### PR TITLE
Keep keyword list format when it's the last element of a tuple

### DIFF
--- a/lib/sourceror/code/normalizer.ex
+++ b/lib/sourceror/code/normalizer.ex
@@ -187,6 +187,11 @@ defmodule Sourceror.Code.Normalizer do
     end
   end
 
+  # Tuples
+  defp do_normalize({:{}, _, args} = quoted, state) when is_list(args) do
+    normalize_literal(quoted, [], state)
+  end
+
   # Calls
   defp do_normalize({_, _, args} = quoted, state) when is_list(args) do
     normalize_call(quoted, state)
@@ -232,11 +237,29 @@ defmodule Sourceror.Code.Normalizer do
     end
   end
 
+  # Tuples
+  defp normalize_literal({:{}, _, args} = quoted, meta, state) do
+    last_arg = List.last(args)
+
+    with [{{:__block__, key_meta, _}, _} | _] <- last_arg, :keyword <- key_meta[:format] do
+      {:__block__, meta, [quoted]}
+    else
+      _ ->
+        normalize_call(quoted, state)
+    end
+  end
+
   # 2-tuples
   defp normalize_literal({left, right}, meta, state) do
     meta = patch_meta_line(meta, state.parent_meta)
     state = %{state | parent_meta: meta}
-    {:__block__, meta, [{do_normalize(left, state), do_normalize(right, state)}]}
+
+    with [{{:__block__, key_meta, _}, _} | _] <- right, :keyword <- key_meta[:format] do
+      {:__block__, meta, [{do_normalize(left, state), right}]}
+    else
+      _ ->
+        {:__block__, meta, [{do_normalize(left, state), do_normalize(right, state)}]}
+    end
   end
 
   # Lists

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -203,6 +203,22 @@ defmodule SourcerorTest do
       assert "1, 2, 3" == Sourceror.to_string([1, 2, 3], format: :splicing)
       assert "{:foo, :bar}" == Sourceror.to_string({:foo, :bar}, format: :splicing)
     end
+
+    test "last tuple element as keyword list must keep its format" do
+      code = ~S({:wrapped, [opt1: true, opt2: false]})
+      assert code |> Sourceror.parse_string!() |> Sourceror.to_string() == code
+
+      code = ~S({:unwrapped, opt1: true, opt2: false})
+      assert code |> Sourceror.parse_string!() |> Sourceror.to_string() == code
+    end
+
+    test "last tuple element as keyword list must keep its format (2-tuples)" do
+      code = ~S({:wrapped, 1, [opt1: true, opt2: false]})
+      assert code |> Sourceror.parse_string!() |> Sourceror.to_string() == code
+
+      code = ~S({:unwrapped, 1, opt1: true, opt2: false})
+      assert code |> Sourceror.parse_string!() |> Sourceror.to_string() == code
+    end
   end
 
   describe "correct_lines/2" do


### PR DESCRIPTION
Tuples accept the last element as unwrapped keyword lists like:

```elixir
{SomeModule, opt1: true, opt2: false}
```

This is quite common in configs/specs like Broadway's configuration.

Currently, whenever using `Sourceror.to_string`, the original format is lost:

```
iex(1)> "{SomeModule, opt1: true, opt2: false}" |> Sourceror.parse_string!() |> Sourceror.to_string()
"{:some_config, [opt1: true, opt2: false]}"
```

This PR fixes the issue. 

@doorgan I'm not familiar with all possible AST nodes and how exactly they can be manipulated without messing things up so there's a big chance I have missed something important :)