### PR TITLE
Add a failing case for comment and pipe idempotency

### DIFF
--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -57,9 +57,13 @@ defmodule SourcerorTest do
 
     # comments and pipeline operator
     assert_same(~S"""
+    function_call()
+
+    # comment for big
     big
+    # comment for long
     |> long()
-    # comment after long and before chain
+    # comment for chain
     |> chain()
     """)
 


### PR DESCRIPTION
testcase for #27 
I know the initial function call looks weird, but without it you don't see the empty newline appear under bop

**in / expected**
```ex
  function_call()

  # comment for big
  big
  # comment for long
  |> long()
  # comment for chain
  |> chain()
```

**out**
```ex
  function_call()

  big
  |> long()

  # comment for big
  # comment for long
  # comment for chain
  |> chain()
```