### PR TITLE
Add failing test for blank lines around comments

### DIFF
--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -76,6 +76,13 @@ defmodule SourcerorTest do
     """)
 
     assert_same(~S"""
+    # a
+
+    # b
+    foo = bar()
+    """)
+
+    assert_same(~S"""
     [
       1,
       # a


### PR DESCRIPTION
Ran sourceror on a large codebase and found two remaining issues. Here's the first.

The test adds a case of comment - blank - comment, but i've additionally see it in places that aren't comments:

```diff
     Something.Foo.init(Something.Foo.ETS)
-
     # comment comment comment
```
```diff
 config :app, bar: 500
-
 config :other_app, :foo, true
```