### PR TITLE
Add Zipper.skip/2

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -163,7 +163,7 @@ defmodule Sourceror.Zipper do
   end
 
   @doc """
-  "Returns the zipper of the right sibling of the node at this zipper, or nil.
+  Returns the zipper of the right sibling of the node at this zipper, or nil.
   """
   @spec right(zipper) :: zipper | nil
   def right({_, nil}), do: nil
@@ -292,11 +292,31 @@ defmodule Sourceror.Zipper do
   def next({_, :end} = zipper), do: zipper
 
   def next({tree, _} = zipper) do
-    if branch?(tree) && down(zipper), do: down(zipper), else: next_right(zipper)
+    if branch?(tree) && down(zipper), do: down(zipper), else: skip(zipper)
   end
 
-  defp next_right(zipper) do
+  @doc """
+  Returns the zipper of the right sibling of the node at this zipper, or the
+  next zipper when no right sibling is available.
+
+  If no right sibling is available, this function returns the same value as
+  `next/1`.
+
+  The optional seconde parameters specifies the `direction`, defaults to
+  `:next`.
+
+  The function `skip/1` behaves like the `:skip` in `traverse_while/2` and
+  `traverse_while/3`.
+  """
+  @spec skip(zipper, direction :: :next | :prev) :: zipper
+  def skip(zipper, direction \\ :next)
+
+  def skip(zipper, :next) do
     if next = right(zipper), do: next, else: next_up(zipper)
+  end
+
+  def skip(zipper, :prev) do
+    if prev = left(zipper), do: prev, else: prev_up(zipper)
   end
 
   defp next_up(zipper) do
@@ -304,6 +324,16 @@ defmodule Sourceror.Zipper do
 
     if parent do
       right(parent) || next_up(parent)
+    else
+      {node(zipper), :end}
+    end
+  end
+
+  defp prev_up(zipper) do
+    parent = up(zipper)
+
+    if parent do
+      left(parent) || prev_up(parent)
     else
       {node(zipper), :end}
     end
@@ -418,7 +448,7 @@ defmodule Sourceror.Zipper do
   defp do_traverse_while(zipper, fun) do
     case fun.(zipper) do
       {:cont, zipper} -> zipper |> next() |> do_traverse_while(fun)
-      {:skip, zipper} -> zipper |> next_right() |> do_traverse_while(fun)
+      {:skip, zipper} -> zipper |> skip() |> do_traverse_while(fun)
       {:halt, zipper} -> top(zipper)
     end
   end
@@ -453,7 +483,7 @@ defmodule Sourceror.Zipper do
   defp do_traverse_while(zipper, acc, fun) do
     case fun.(zipper, acc) do
       {:cont, zipper, acc} -> zipper |> next() |> do_traverse_while(acc, fun)
-      {:skip, zipper, acc} -> zipper |> next_right() |> do_traverse_while(acc, fun)
+      {:skip, zipper, acc} -> zipper |> skip() |> do_traverse_while(acc, fun)
       {:halt, zipper, acc} -> {top(zipper), acc}
     end
   end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -220,6 +220,24 @@ defmodule SourcerorTest.ZipperTest do
     end
   end
 
+  describe "skip/2" do
+    test "adsf" do
+      zipper =
+        Z.zip([
+          {:foo, [], [1, 2, 3]},
+          {:bar, [], [1, 2, 3]},
+          {:baz, [], [1, 2, 3]}
+        ])
+
+      zipper = Z.down(zipper)
+
+      assert Z.node(zipper) == {:foo, [], [1, 2, 3]}
+      assert zipper |> Z.skip() |> Z.node() == {:bar, [], [1, 2, 3]}
+      assert zipper |> Z.skip(:next) |> Z.node() == {:bar, [], [1, 2, 3]}
+      assert zipper |> Z.skip() |> Z.skip(:prev) |> Z.node() == {:foo, [], [1, 2, 3]}
+    end
+  end
+
   describe "end?/1" do
     test "returns true if it's an end zipper" do
       assert Z.end?({42, nil}) == false


### PR DESCRIPTION
The function `Zipper.skip/2` behaves like the `:skip` in `Zipper.travers_while/2`. `Zipper.skip/2` can also go back in the tree with `Zipper.skip(zipper, :prev)`.