### PR TITLE
Add direction to Zipper.find

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -493,14 +493,30 @@ defmodule Sourceror.Zipper do
   @doc """
   Returns a zipper to the node that satisfies the predicate function, or `nil`
   if none is found.
-  """
-  def find({_, :end}, _), do: nil
 
-  def find({tree, _} = zipper, predicate) do
+  The optional second parameters specifies the `direction`, defaults to
+  `:next`.
+  """
+  @spec find(zipper, direction :: :prev | :next, predicate :: (tree -> any)) ::
+          zipper | nil
+  def find(zipper, direction \\ :next, predicate)
+
+  def find(nil, _direction, _predicate), do: nil
+
+  def find({_, :end}, :next, _predicate), do: nil
+
+  def find({tree, _} = zipper, direction, predicate)
+      when direction in [:next, :prev] and is_function(predicate) do
     if predicate.(tree) do
       zipper
     else
-      find(next(zipper), predicate)
+      zipper =
+        case direction do
+          :next -> next(zipper)
+          :prev -> prev(zipper)
+        end
+
+      find(zipper, direction, predicate)
     end
   end
 

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -466,11 +466,43 @@ defmodule SourcerorTest.ZipperTest do
     end
   end
 
-  describe "find/2" do
+  describe "find/3" do
     test "finds a zipper with a predicate" do
       zipper = Z.zip([1, [2, [3, 4], 5]])
 
       assert Z.find(zipper, fn x -> x == 4 end) |> Z.node() == 4
+      assert Z.find(zipper, :next, fn x -> x == 4 end) |> Z.node() == 4
+    end
+
+    test "returns nil if nothing was found" do
+      zipper = Z.zip([1, [2, [3, 4], 5]])
+
+      assert Z.find(zipper, fn x -> x == 9 end) == nil
+      assert Z.find(zipper, :prev, fn x -> x == 9 end) == nil
+    end
+
+    test "finds a zipper with a predicate in direction :prev" do
+      zipper =
+        [1, [2, [3, 4], 5]]
+        |> Z.zip()
+        |> Z.next()
+        |> Z.next()
+        |> Z.next()
+        |> Z.next()
+
+      assert Z.find(zipper, :prev, fn x -> x == 2 end) |> Z.node() == 2
+    end
+
+    test "retruns nil if nothing was found in direction :prev" do
+      zipper =
+        [1, [2, [3, 4], 5]]
+        |> Z.zip()
+        |> Z.next()
+        |> Z.next()
+        |> Z.next()
+        |> Z.next()
+
+      assert Z.find(zipper, :prev, fn x -> x == 9 end) == nil
     end
   end
 end


### PR DESCRIPTION
This PR adds an optional `direction` argument to `Zipper.find`.