### PR TITLE
Fix/update patch_string/2 indentation behavior

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -684,11 +684,30 @@ defmodule Sourceror do
   @doc """
   Applies one or more patches to the given string.
 
-  This functions limits itself to apply the patches in order, but it does not
-  check for overlapping ranges, so make sure to pass non-overlapping patches.
+  A patch is a map containing the following values:
 
-  A patch is a map containing at least the range that it should patch, and the
-  change to be applied in the range, for example:
+    * `:range` - a map containing `:start` and `:end` keys, whose values are
+      keyword lists containing the `:line` and `:column` representing the
+      boundary of the patch.
+    * `:change` - the string being patched in or a function that takes the
+      text of the patch range and returns the replacement.
+    * `:preserve_indentation` (default `true`) - whether to automatically
+      correct the indentation of the patch string to preserve the indentation
+      level of the patch range (see examples below)
+
+  Note that `:line` and `:column` start at 1 and represent a cursor positioned
+  before the targeted position. For instance, here's how you would select the
+  string `"ToBePatched"` in the following example:
+
+      defmodule ToBePatched do
+      #         ^          ^
+      # col     11         22
+
+      %{range: %{start: [line: 1, column: 11], end: [line: 1, column: 22]}}
+
+  Ranges are usually derived from parsed AST nodes. See `get_range/2` for more.
+
+  ## Examples
 
       iex> original = ~S"\""
       ...> if not allowed? do
@@ -722,7 +741,7 @@ defmodule Sourceror do
       "\""
 
   By default, lines after the first line of the patch will be indented relative to
-  the indentation level of the patched first line:
+  the indentation level at the start of the range:
 
       iex> original = ~S"\""
       ...> outer do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -808,6 +808,37 @@ defmodule SourcerorTest do
              """
     end
 
+    test "patches multiline ranges" do
+      original = ~S"""
+      foo do
+        some_call(bar do
+          :baz
+          end)
+      end
+      """
+
+      patch_text =
+        ~S"""
+        whatever do
+          :inner
+        end
+        """
+        |> String.trim()
+
+      patch = %{
+        change: patch_text,
+        range: %{start: [line: 2, column: 13], end: [line: 4, column: 8]}
+      }
+
+      assert Sourceror.patch_string(original, [patch]) == ~S"""
+             foo do
+               some_call(whatever do
+                 :inner
+               end)
+             end
+             """
+    end
+
     test "patches single line range with multiple lines" do
       original = ~S"""
       hello world do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -733,17 +733,17 @@ defmodule SourcerorTest do
              """
     end
 
-    test "multiple patches in single line" do
+    test "patches multiple ranges in a single line" do
       original = ~S"foo bar baz"
 
       patches = [
         %{
-          change: "a",
-          range: %{start: [line: 1, column: 1], end: [line: 1, column: 4]}
-        },
-        %{
           change: "something long",
           range: %{start: [line: 1, column: 5], end: [line: 1, column: 8]}
+        },
+        %{
+          change: "a",
+          range: %{start: [line: 1, column: 1], end: [line: 1, column: 4]}
         },
         %{
           change: "c",
@@ -752,6 +752,35 @@ defmodule SourcerorTest do
       ]
 
       assert Sourceror.patch_string(original, patches) == ~S"a something long c"
+    end
+
+    test "patches multiple ranges in a single line with single and multiline changes" do
+      original = ~S"foo bar baz"
+
+      patches = [
+        %{
+          change: "something long",
+          range: %{start: [line: 1, column: 5], end: [line: 1, column: 8]}
+        },
+        %{
+          change: "a",
+          range: %{start: [line: 1, column: 1], end: [line: 1, column: 4]}
+        },
+        %{
+          change: """
+          [
+            next
+          ]
+          """,
+          range: %{start: [line: 1, column: 9], end: [line: 1, column: 12]}
+        }
+      ]
+
+      assert Sourceror.patch_string(original, patches) == ~S"""
+             a something long [
+               next
+             ]
+             """
     end
 
     test "patches multiple line ranges" do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -733,35 +733,6 @@ defmodule SourcerorTest do
              """
     end
 
-    test "patches single line range with multiple lines" do
-      original = ~S"""
-      hello world do
-        :ok
-      end
-      """
-
-      patch = %{
-        change: """
-        [
-          1,
-          2,
-          3
-        ]\
-        """,
-        range: %{start: [line: 2, column: 3], end: [line: 2, column: 6]}
-      }
-
-      assert Sourceror.patch_string(original, [patch]) == ~S"""
-             hello world do
-               [
-                 1,
-                 2,
-                 3
-               ]
-             end
-             """
-    end
-
     test "multiple patches in single line" do
       original = ~S"foo bar baz"
 
@@ -834,6 +805,65 @@ defmodule SourcerorTest do
              foo do baz do
                  :not_ok
                end end
+             """
+    end
+
+    test "patches single line range with multiple lines" do
+      original = ~S"""
+      hello world do
+        :ok
+      end
+      """
+
+      patch = %{
+        change: """
+        [
+          1,
+          2,
+          3
+        ]\
+        """,
+        range: %{start: [line: 2, column: 3], end: [line: 2, column: 6]}
+      }
+
+      assert Sourceror.patch_string(original, [patch]) == ~S"""
+             hello world do
+               [
+                 1,
+                 2,
+                 3
+               ]
+             end
+             """
+    end
+
+    test "patches single line range with multiple lines allowing user to skip indentation fixes" do
+      original = ~S"""
+      hello world do
+        :ok
+      end
+      """
+
+      patch = %{
+        change: """
+        [
+          1,
+          2,
+          3
+        ]\
+        """,
+        range: %{start: [line: 2, column: 3], end: [line: 2, column: 6]},
+        preserve_indentation: false
+      }
+
+      assert Sourceror.patch_string(original, [patch]) == ~S"""
+             hello world do
+               [
+               1,
+               2,
+               3
+             ]
+             end
              """
     end
 

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -733,6 +733,35 @@ defmodule SourcerorTest do
              """
     end
 
+    test "patches single line range with multiple lines" do
+      original = ~S"""
+      hello world do
+        :ok
+      end
+      """
+
+      patch = %{
+        change: """
+        [
+          1,
+          2,
+          3
+        ]\
+        """,
+        range: %{start: [line: 2, column: 3], end: [line: 2, column: 6]}
+      }
+
+      assert Sourceror.patch_string(original, [patch]) == ~S"""
+             hello world do
+               [
+                 1,
+                 2,
+                 3
+               ]
+             end
+             """
+    end
+
     test "multiple patches in single line" do
       original = ~S"foo bar baz"
 

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -781,33 +781,6 @@ defmodule SourcerorTest do
              """
     end
 
-    test "patches multiline ranges without beaking indentation" do
-      original = ~S"""
-      foo do bar do
-        :ok
-        end end
-      """
-
-      patch_text =
-        ~S"""
-        baz do
-          :not_ok
-        end
-        """
-        |> String.trim()
-
-      patch = %{
-        change: patch_text,
-        range: %{start: [line: 1, column: 8], end: [line: 3, column: 6]}
-      }
-
-      assert Sourceror.patch_string(original, [patch]) == ~S"""
-             foo do baz do
-                 :not_ok
-               end end
-             """
-    end
-
     test "patches multiline ranges" do
       original = ~S"""
       foo do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -839,6 +839,33 @@ defmodule SourcerorTest do
                ]
              end
              """
+
+      original = """
+      outer do
+        inner :ok
+      end
+      """
+
+      patch = %{
+        change: """
+        [
+          1,
+          2,
+          3
+        ]\
+        """,
+        range: %{start: [line: 2, column: 9], end: [line: 2, column: 12]}
+      }
+
+      assert Sourceror.patch_string(original, [patch]) == ~S"""
+             outer do
+               inner [
+                 1,
+                 2,
+                 3
+               ]
+             end
+             """
     end
 
     test "patches single line range with multiple lines allowing user to skip indentation fixes" do


### PR DESCRIPTION
This PR makes the following changes to `patch_string/2`:

* Indentation is more consistent/predictable and correctly applies to multi-line changes for for single and multi-line ranges;
* Refactored such that single and multi-line patches are handled in the same way;
* Documentation has been updated.

The changes are probably best seen by example:

## Example 1

```elixir
original =
  ~S"""
  foo do
    some_call(bar do
      :baz
      end)
  end
  """

patch_text =
  ~S"""
  whatever do
    :inner
  end\
  """

patch = %{
  change: patch_text,
  range: %{start: [line: 2, column: 13], end: [line: 4, column: 8]}
}

# before this PR
Sourceror.patch_string(original, [patch]) ==
  ~S"""
  foo do
    some_call(whatever do
        :inner
      end)
  end
  """

# after this PR
Sourceror.patch_string(original, [patch]) ==
  ~S"""
  foo do
    some_call(whatever do
      :inner
    end)
  end
  """
```

## Example 2

```elixir
original =
  ~S"""
  hello world do
    :ok
  end
  """

patch = %{
  change: """
  [
    1,
    2,
    3
  ]\
  """,
  range: %{start: [line: 2, column: 3], end: [line: 2, column: 6]}
}

# before this PR
Sourceror.patch_string(original, [patch]) ==
  ~S"""
  hello world do
    [
    1,
    2,
    3
  ]
  end
  """

# after this PR
Sourceror.patch_string(original, [patch]) ==
  ~S"""
  hello world do
    [
      1,
      2,
      3
    ]
  end
  """
```

