### PR TITLE
Subtract newline from column count when calculating end position

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -537,7 +537,18 @@ defmodule Sourceror do
     get_meta(quoted)
     |> Keyword.take(@end_fields)
     |> Keyword.values()
-    |> Enum.map(&Keyword.take(&1, [:line, :column]))
+    |> Enum.map(fn end_field ->
+      position = Keyword.take(end_field, [:line, :column])
+
+      # If the node contains newlines, a newline is included in the
+      # column count. We subtract it so that the column represents the
+      # last non-whitespace character.
+      if Keyword.has_key?(end_field, :newlines) do
+        Keyword.update(position, :column, nil, &(&1 - 1))
+      else
+        position
+      end
+    end)
     |> Enum.concat([start_position])
     |> Enum.max_by(
       & &1,

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -487,6 +487,27 @@ defmodule SourcerorTest do
                end: [line: 3, column: 2]
              }
     end
+
+    test "returns the correct column for nested blocks" do
+      quoted =
+        ~S"""
+        bar 1
+        bar
+        """
+        |> Sourceror.parse_string!()
+
+      {_, _, [bar1, bar]} = quoted
+
+      assert Sourceror.get_range(bar) == %{
+               start: [line: 2, column: 1],
+               end: [line: 2, column: 4]
+             }
+
+      assert Sourceror.get_range(bar1) == %{
+               start: [line: 1, column: 1],
+               end: [line: 1, column: 6]
+             }
+    end
   end
 
   describe "prepend_comments/3" do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -439,6 +439,21 @@ defmodule SourcerorTest do
         |> Sourceror.parse_string!()
 
       assert Sourceror.get_end_position(quoted) == [line: 4, column: 4]
+
+      quoted =
+        ~S"""
+        foo(1)
+        foo 1
+        foo bar()
+        _
+        """
+        |> Sourceror.parse_string!()
+
+      {_, _, [parens, without_parens, nested, _]} = quoted
+
+      assert Sourceror.get_end_position(parens) == [line: 1, column: 6]
+      assert Sourceror.get_end_position(without_parens) == [line: 2, column: 5]
+      assert Sourceror.get_end_position(nested) == [line: 3, column: 9]
     end
   end
 
@@ -488,24 +503,31 @@ defmodule SourcerorTest do
              }
     end
 
-    test "returns the correct column for nested blocks" do
+    test "returns the correct column for calls with and without parens" do
       quoted =
         ~S"""
-        bar 1
-        bar
+        foo(1)
+        foo 1
+        foo bar()
+        _
         """
         |> Sourceror.parse_string!()
 
-      {_, _, [bar1, bar]} = quoted
+      {_, _, [parens, without_parens, nested_without_parens, _]} = quoted
 
-      assert Sourceror.get_range(bar) == %{
-               start: [line: 2, column: 1],
-               end: [line: 2, column: 4]
+      assert Sourceror.get_range(parens) == %{
+               start: [line: 1, column: 1],
+               end: [line: 1, column: 7]
              }
 
-      assert Sourceror.get_range(bar1) == %{
-               start: [line: 1, column: 1],
-               end: [line: 1, column: 6]
+      assert Sourceror.get_range(without_parens) == %{
+               start: [line: 2, column: 1],
+               end: [line: 2, column: 6]
+             }
+
+      assert Sourceror.get_range(nested_without_parens) == %{
+               start: [line: 3, column: 1],
+               end: [line: 3, column: 10]
              }
     end
   end


### PR DESCRIPTION
This PR fixes a bug that caused the end position column to be one larger than it should be in cases where the node metadata contains newline information.

This is best seen by example:

```elixir
iex(1)> string = """
...(1)> foo 1
...(1)> bar 2
...(1)> baz 3
...(1)> """
"foo 1\nbar 2\nbaz 3\n"
iex(2)> {_, _, [foo, bar, baz]} = Sourceror.parse_string!(string)
{:__block__, [trailing_comments: [], leading_comments: []],
 [
   {:foo,
    [
      trailing_comments: [],
      leading_comments: [],
      end_of_expression: [newlines: 1, line: 1, column: 6],
      line: 1,
      column: 1
    ],
    [
      {:__block__, [trailing_comments: [], leading_comments: [], token: "1", line: 1, column: 5],
       [1]}
    ]},
   {:bar,
    [
      trailing_comments: [],
      leading_comments: [],
      end_of_expression: [newlines: 1, line: 2, column: 6],
      line: 2,
      column: 1
    ],
    [
      {:__block__, [trailing_comments: [], leading_comments: [], token: "2", line: 2, column: 5],
       [2]}
    ]},
   {:baz, [trailing_comments: [], leading_comments: [], line: 3, column: 1],
    [
      {:__block__, [trailing_comments: [], leading_comments: [], token: "3", line: 3, column: 5],
       [3]}
    ]}
 ]}
iex(3)> Sourceror.get_end_position(foo)
[line: 1, column: 6]
iex(4)> Sourceror.get_end_position(bar)
[line: 2, column: 6]
iex(5)> Sourceror.get_end_position(baz)
[line: 3, column: 5]
```

The `foo` and `bar` expressions report the column of the trailing newline, while the last `baz` expression does not. This becomes problematic in conjunction with `get_range`, which increments the end column by 1 so that it's exclusive -- this causes the range to report the column as 7 for the examples above.

I found this bug due to the new way that newlines are handled in `patch_string` -- they remain at the end of each line, whereas previously they were stripped and re-added later. So when `get_range` returned a column that was 1 larger than it should be, the newline would be included in the range to be replaced, causing newlines to be dropped.