### PR TITLE
Remove the concept of an ended zipper from Zipper

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -25,10 +25,10 @@ defmodule Sourceror.Zipper do
 
   @type tree :: Macro.t()
   @type path :: %{
-          l: [tree],
-          ptree: zipper,
-          r: [tree]
-        }
+            l: [tree],
+            ptree: zipper,
+            r: [tree]
+          }
   @type zipper :: {tree, path | nil}
 
   @doc """
@@ -268,18 +268,10 @@ defmodule Sourceror.Zipper do
   The function `skip/1` behaves like the `:skip` in `traverse_while/2` and
   `traverse_while/3`.
   """
-  @spec skip(zipper, direction :: :next | :prev) :: zipper
+  @spec skip(zipper, direction :: :next | :prev) :: zipper | nil
   def skip(zipper, direction \\ :next)
-
-  def skip({_, nil}, :prev), do: nil
-
-  def skip(zipper, :next) do
-    if next = right(zipper), do: next, else: next_up(zipper)
-  end
-
-  def skip(zipper, :prev) do
-    if prev = left(zipper), do: prev, else: prev_up(zipper)
-  end
+  def skip(zipper, :next), do: right(zipper) || next_up(zipper)
+  def skip(zipper, :prev), do: left(zipper) || prev_up(zipper)
 
   defp next_up(zipper) do
     if parent = up(zipper) do

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -25,10 +25,10 @@ defmodule Sourceror.Zipper do
 
   @type tree :: Macro.t()
   @type path :: %{
-            l: [tree],
-            ptree: zipper,
-            r: [tree]
-          }
+          l: [tree],
+          ptree: zipper,
+          r: [tree]
+        }
   @type zipper :: {tree, path | nil}
 
   @doc """

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -24,11 +24,11 @@ defmodule Sourceror.Zipper do
   import Kernel, except: [node: 1]
 
   @type tree :: Macro.t()
-  @opaque path :: %{
-            l: [tree],
-            ptree: zipper,
-            r: [tree]
-          }
+  @type path :: %{
+          l: [tree],
+          ptree: zipper,
+          r: [tree]
+        }
   @type zipper :: {tree, path | nil}
 
   @doc """

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -317,7 +317,7 @@ defmodule Sourceror.Zipper do
 
   @doc """
   Traverses the tree in depth-first pre-order calling the given function for
-  each node.
+  each node. When the traversal is finished, the zipper will be back where it began.
 
   If the zipper is not at the top, just the subtree will be traversed.
 
@@ -340,7 +340,8 @@ defmodule Sourceror.Zipper do
 
   @doc """
   Traverses the tree in depth-first pre-order calling the given function for
-  each node with an accumulator.
+  each node with an accumulator. When the traversal is finished, the zipper
+  will be back where it began.
 
   If the zipper is not at the top, just the subtree will be traversed.
   """
@@ -364,7 +365,8 @@ defmodule Sourceror.Zipper do
   each node.
 
   The traversing will continue if the function returns `{:cont, zipper}`,
-  skipped for `{:skip, zipper}` and halted for `{:halt, zipper}`
+  skipped for `{:skip, zipper}` and halted for `{:halt, zipper}`. When the
+  traversal is finished, the zipper will be back where it began.
 
   If the zipper is not at the top, just the subtree will be traversed.
 
@@ -376,7 +378,6 @@ defmodule Sourceror.Zipper do
              {:cont, zipper} | {:halt, zipper} | {:skip, zipper})
         ) ::
           zipper
-
   def traverse_while({_tree, nil} = zipper, fun) do
     do_traverse_while(zipper, fun)
   end
@@ -401,7 +402,8 @@ defmodule Sourceror.Zipper do
 
   @doc """
   Traverses the tree in depth-first pre-order calling the given function for
-  each node with an accumulator.
+  each node with an accumulator. When the traversal is finished, the zipper
+  will be back where it began.
 
   The traversing will continue if the function returns `{:cont, zipper, acc}`,
   skipped for `{:skip, zipper, acc}` and halted for `{:halt, zipper, acc}`


### PR DESCRIPTION
See #67 

This allows for repeated traversals on the same zipper. 

Clients will have to be more wary about extra calls to "next" or "skip" and similar functions when there is no subsequent node to go to, as they'll get `nil` instead of `{previous_zipper, :end}`, which will lead to function clause errors with subsequent Zipper calls. Still, this could be helpful for finding bugs in tree-walking algorithms that should've exited sooner.