### PR TITLE
End traverse if traverse-function returns nil

### DIFF
--- a/lib/sourceror/identifier.ex
+++ b/lib/sourceror/identifier.ex
@@ -3,7 +3,7 @@ defmodule Sourceror.Identifier do
   Functions to identify an classify forms and quoted expressions.
   """
 
-  @unary_ops [:&, :!, :^, :not, :+, :-, :~~~, :@]
+  @unary_ops [:&, :!, :^, :not, :+, :-, :"~~~", :@]
   binary_ops = [
     :<-,
     :\\,
@@ -34,9 +34,9 @@ defmodule Sourceror.Identifier do
     :<<~,
     :~>>,
     :<~>,
-    :<|>,
+    :"<|>",
     :in,
-    :^^^,
+    :"^^^",
     :"//",
     :++,
     :--,
@@ -55,7 +55,7 @@ defmodule Sourceror.Identifier do
                  binary_ops
                end)
 
-  @pipeline_operators [:|>, :~>>, :<<~, :~>, :<~, :<~>, :<|>]
+  @pipeline_operators [:|>, :~>>, :<<~, :~>, :<~, :<~>, :"<|>"]
 
   @doc """
   Checks if the given identifier is an unary op.

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -326,8 +326,13 @@ defmodule Sourceror.Zipper do
   end
 
   defp do_traverse(zipper, fun) do
-    zipper = fun.(zipper)
-    if next = next(zipper), do: do_traverse(next, fun), else: top(zipper)
+    case fun.(zipper) do
+      nil ->
+        top(zipper)
+
+      zipper ->
+        if next = next(zipper), do: do_traverse(next, fun), else: top(zipper)
+    end
   end
 
   @doc """
@@ -348,8 +353,13 @@ defmodule Sourceror.Zipper do
   end
 
   defp do_traverse(zipper, acc, fun) do
-    {zipper, acc} = fun.(zipper, acc)
-    if next = next(zipper), do: do_traverse(next, acc, fun), else: {top(zipper), acc}
+    case fun.(zipper, acc) do
+      {nil, acc} ->
+        {top(zipper), acc}
+
+      {zipper, acc} ->
+        if next = next(zipper), do: do_traverse(next, acc, fun), else: {top(zipper), acc}
+    end
   end
 
   @doc """

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -283,6 +283,16 @@ defmodule SourcerorTest.ZipperTest do
              end)
              |> Z.root() == [1, [12, [13, 14], 15], [6, 7]]
     end
+
+    test "traverses in depth-first pre-order and skips last node" do
+      zipper = Z.zip([1, 2, 3])
+
+      assert Z.traverse(zipper, fn
+               {3, _m} = z -> Z.skip(z)
+               {x, m} when is_integer(x) -> {x + 10, m}
+               z -> z
+             end) == {[11, 12, 3], nil}
+    end
   end
 
   describe "traverse/3" do
@@ -316,6 +326,16 @@ defmodule SourcerorTest.ZipperTest do
         |> Z.traverse([], &{&1, [Z.node(&1) | &2]})
 
       assert [[2, [3, 4], 5], 2, [3, 4], 3, 4, 5] == Enum.reverse(acc)
+    end
+
+    test "traverses in depth-first pre-order and skips last node" do
+      zipper = Z.zip([1, 2, 3])
+
+      assert Z.traverse(zipper, [], fn
+               {3, _m} = z, acc -> {Z.skip(z), acc}
+               {x, m}, acc when is_integer(x) -> {{x + 10, m}, [x | acc]}
+               z, acc -> {z, acc}
+             end) == {{[11, 12, 3], nil}, [2, 1]}
     end
   end
 


### PR DESCRIPTION
Hi doorgan

After the zipper end concept has changed the traverse functions should also stop if the given function returns `nil`. This makes it possible to still use `Zipper.skip/1` in this functions.