### PR TITLE
Fix `Sourceror.get_range/1` for anonymous calls

### DIFF
--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -328,8 +328,19 @@ defmodule SourcerorTest.RangeTest do
     test "qualified calls" do
       assert to_range(~S/foo.bar/) == %{start: [line: 1, column: 1], end: [line: 1, column: 8]}
       assert to_range(~S/foo.bar()/) == %{start: [line: 1, column: 1], end: [line: 1, column: 10]}
+      assert to_range(~S/foo.()/) == %{start: [line: 1, column: 1], end: [line: 1, column: 7]}
+
+      assert to_range(~S/foo.bar.()/) == %{
+               start: [line: 1, column: 1],
+               end: [line: 1, column: 11]
+             }
 
       assert to_range(~s/foo.bar(\n)/) == %{
+               start: [line: 1, column: 1],
+               end: [line: 2, column: 2]
+             }
+
+      assert to_range(~s/foo.bar.(\n)/) == %{
                start: [line: 1, column: 1],
                end: [line: 2, column: 2]
              }
@@ -339,6 +350,16 @@ defmodule SourcerorTest.RangeTest do
       assert to_range(~S/foo.bar(baz)/) == %{
                start: [line: 1, column: 1],
                end: [line: 1, column: 13]
+             }
+
+      assert to_range(~S/foo.bar.(baz)/) == %{
+               start: [line: 1, column: 1],
+               end: [line: 1, column: 14]
+             }
+
+      assert to_range(~s/foo.bar.(\nbaz)/) == %{
+               start: [line: 1, column: 1],
+               end: [line: 2, column: 5]
              }
 
       assert to_range(~S/foo.bar("baz#{2}qux")/) == %{


### PR DESCRIPTION
There wasn't a `do_get_range` case that matched `foo.()` or `foo.(arg)` because the qualified call cases always assumed there were both a left and right value. I started by confirming copy-pasting the relevant function clauses but removing the `right` made the tests pass, then just factored the bodies into shared helpers while keeping the explicit matching in `do_get_range`.