### PR TITLE
Comment idempotency test failures

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -314,6 +314,9 @@ defmodule Sourceror.Zipper do
   If the zipper is not at the top, just the subtree will be traversed.
 
   The function must return a zipper.
+
+  If you want to optimize the traversal by skipping certain subtrees, consider
+  using `traverse_while/2` instead.
   """
   @spec traverse(zipper, (zipper -> zipper)) :: zipper
   def traverse({_tree, nil} = zipper, fun) do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -38,12 +38,16 @@ defmodule SourcerorTest do
       # A
       foo do
         # B
-        :ok
 
         # C
+
+        :ok
+        # D
+
+        # E
       end
 
-      # D
+      # F
       """)
     end
 


### PR DESCRIPTION
Ran `code |> Sourceror.parse_string!() |> Sourceror.to_string()`  on every file in a large codebase and found two classes of comment errors on the output. Both are covered by this failing test case update

Decent chance I can use work hours to try to figure this out myself on Monday - if you have ideas of where I should go look please point me that way =)

Also added docs for traverse optimization