### PR TITLE
Support `locals_without_parens` in the formatter.exs of local projects

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -913,7 +913,7 @@ defmodule Sourceror do
     |> Enum.map(&Enum.join/1)
   end
 
-  def locals_without_parens() do
+  defp locals_without_parens() do
     if Version.match?(System.version(), ">= 1.13.0") do
       File.cwd!()
       |> Path.join(".formatter.exs")

--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -199,14 +199,11 @@ defmodule Sourceror do
     extract_comments_opts = [collapse_comments: true, correct_lines: true] ++ opts
 
     {quoted, comments} = Sourceror.Comments.extract_comments(quoted, extract_comments_opts)
-    locals_without_parens = Keyword.get(opts, :locals_without_parens, locals_without_parens())
 
     to_algebra_opts =
-      Keyword.merge(opts,
-        comments: comments,
-        escape: false,
-        locals_without_parens: locals_without_parens
-      )
+      opts
+      |> Keyword.merge(comments: comments, escape: false)
+      |> Keyword.put_new(:locals_without_parens, locals_without_parens())
 
     text =
       quoted

--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -915,11 +915,8 @@ defmodule Sourceror do
 
   defp locals_without_parens() do
     if Version.match?(System.version(), ">= 1.13.0") do
-      File.cwd!()
-      |> Path.join(".formatter.exs")
-      |> Mix.Tasks.Format.formatter_for_file()
-      |> elem(1)
-      |> Keyword.get(:locals_without_parens, [])
+      {_formatter, formatter_opts} = Mix.Tasks.Format.formatter_for_file("elixir.ex")
+      Keyword.get(formatter_opts, :locals_without_parens, [])
     else
       []
     end


### PR DESCRIPTION
I verified that the logic of the code works fine in a project that relies on sourceror

<img width="907" alt="image" src="https://user-images.githubusercontent.com/12830256/218924160-24c67e44-e4ab-4e0a-81e3-781b2e7a6f0c.png">

to fix #33