### PR TITLE
Be lazy when adding locals_without_parens to the options

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -208,7 +208,7 @@ defmodule Sourceror do
     to_algebra_opts =
       opts
       |> Keyword.merge(comments: comments, escape: false)
-      |> Keyword.put_new_lazy(:locals_without_parens, locals_without_parens())
+      |> Keyword.put_new_lazy(:locals_without_parens, &locals_without_parens/0)
 
     text =
       quoted

--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -208,7 +208,7 @@ defmodule Sourceror do
     to_algebra_opts =
       opts
       |> Keyword.merge(comments: comments, escape: false)
-      |> Keyword.put_new(:locals_without_parens, locals_without_parens())
+      |> Keyword.put_new_lazy(:locals_without_parens, locals_without_parens())
 
     text =
       quoted


### PR DESCRIPTION
`Keyword.put_new/3` will always execute `locals_without_parens/1` even we have `:locals_without_parens` in the `opts`.
Should fix #87 