### PR TITLE
Add additional identification guards to `Sourceror.Identifier`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
             run_dialyzer: true
           - elixir: '1.14.3'
             otp: '25.2'
+          - elixir: '1.15.5'
+            otp: '26'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir

--- a/lib/sourceror/identifier.ex
+++ b/lib/sourceror/identifier.ex
@@ -85,7 +85,7 @@ defmodule Sourceror.Identifier do
       iex> is_unary_op(:+)
       true
   """
-  @spec is_unary_op(Macro.t()) :: boolean()
+  @spec is_unary_op(Macro.t()) :: Macro.t()
   defguard is_unary_op(op) when is_atom(op) and op in @unary_ops
 
   @doc """
@@ -96,7 +96,7 @@ defmodule Sourceror.Identifier do
       iex> is_binary_op(:+)
       true
   """
-  @spec is_binary_op(Macro.t()) :: boolean()
+  @spec is_binary_op(Macro.t()) :: Macro.t()
   defguard is_binary_op(op) when is_atom(op) and op in @binary_ops
 
   @doc """
@@ -107,7 +107,7 @@ defmodule Sourceror.Identifier do
       iex> is_pipeline_op(:|>)
       true
   """
-  @spec is_pipeline_op(Macro.t()) :: boolean()
+  @spec is_pipeline_op(Macro.t()) :: Macro.t()
   defguard is_pipeline_op(op) when is_atom(op) and op in @pipeline_operators
 
   @doc """
@@ -143,7 +143,7 @@ defmodule Sourceror.Identifier do
       iex> "Macro.Env" |> Sourceror.parse_string!() |> is_call()
       false
   """
-  @spec is_call(Macro.t()) :: boolean()
+  @spec is_call(Macro.t()) :: Macro.t()
   defguard is_call(quoted)
            when is_tuple(quoted) and
                   tuple_size(quoted) == 3 and
@@ -179,7 +179,7 @@ defmodule Sourceror.Identifier do
       iex> "Macro.Env" |> Sourceror.parse_string!() |> is_unqualified_call()
       false
   """
-  @spec is_unqualified_call(Macro.t()) :: boolean()
+  @spec is_unqualified_call(Macro.t()) :: Macro.t()
   defguard is_unqualified_call(quoted)
            when is_call(quoted) and is_atom(elem(quoted, 0))
 
@@ -221,7 +221,7 @@ defmodule Sourceror.Identifier do
       iex> "Macro.Env" |> Sourceror.parse_string!() |> is_qualified_call()
       false
   """
-  @spec is_qualified_call(Macro.t()) :: boolean()
+  @spec is_qualified_call(Macro.t()) :: Macro.t()
   defguard is_qualified_call(quoted)
            when is_call(quoted) and
                   is_call(elem(quoted, 0)) and
@@ -241,7 +241,7 @@ defmodule Sourceror.Identifier do
       iex> "1" |> Sourceror.parse_string!() |> is_identifier()
       false
   """
-  @spec is_identifier(Macro.t()) :: boolean()
+  @spec is_identifier(Macro.t()) :: Macro.t()
   defguard is_identifier(quoted)
            when is_tuple(quoted) and
                   tuple_size(quoted) == 3 and
@@ -283,7 +283,7 @@ defmodule Sourceror.Identifier do
       iex> is_atomic_literal('foo')
       false
   """
-  @spec is_atomic_literal(Macro.t()) :: boolean()
+  @spec is_atomic_literal(Macro.t()) :: Macro.t()
   defguard is_atomic_literal(quoted)
            when __is_atomic_literal__(quoted) or __is_atomic_literal_block__(quoted)
 

--- a/lib/sourceror/identifier.ex
+++ b/lib/sourceror/identifier.ex
@@ -13,7 +13,7 @@ defmodule Sourceror.Identifier do
     end
   end
 
-  @unary_ops [:&, :!, :^, :not, :+, :-, :"~~~", :@]
+  @unary_ops [:&, :!, :^, :not, :+, :-, :~~~, :@]
 
   @binary_ops [
                 :<-,
@@ -45,9 +45,9 @@ defmodule Sourceror.Identifier do
                 :<<~,
                 :~>>,
                 :<~>,
-                :"<|>",
+                :<|>,
                 :in,
-                :"^^^",
+                :^^^,
                 :"//",
                 :++,
                 :--,
@@ -62,7 +62,7 @@ defmodule Sourceror.Identifier do
               |> concat_if.("~> 1.12", ~w[+++ ---]a)
               |> concat_if.("~> 1.13", ~w[**]a)
 
-  @pipeline_operators [:|>, :~>>, :<<~, :~>, :<~, :<~>, :"<|>"]
+  @pipeline_operators [:|>, :~>>, :<<~, :~>, :<~, :<~>, :<|>]
 
   @non_call_forms [:__block__, :__aliases__]
 

--- a/lib/sourceror/identifier.ex
+++ b/lib/sourceror/identifier.ex
@@ -215,6 +215,27 @@ defmodule Sourceror.Identifier do
            when is_call(quoted) and is_call(elem(quoted, 0)) and elem(elem(quoted, 0), 0) == :.
 
   @doc """
+  Checks if the given quoted form is an identifier, such as a variable.
+
+  ## Examples
+
+      iex> "node" |> Sourceror.parse_string!() |> is_identifier()
+      true
+
+      iex> "node()" |> Sourceror.parse_string!() |> is_identifier()
+      false
+
+      iex> "1" |> Sourceror.parse_string!() |> is_identifier()
+      false
+  """
+  @spec is_identifier(Macro.t()) :: boolean()
+  defguard is_identifier(quoted)
+           when is_tuple(quoted) and
+                  tuple_size(quoted) == 3 and
+                  is_atom(elem(quoted, 0)) and
+                  is_atom(elem(quoted, 2))
+
+  @doc """
   Checks if the given atom is a valid module alias.
 
   ## Examples

--- a/test/corpus/term/alias.ex
+++ b/test/corpus/term/alias.ex
@@ -28,8 +28,3 @@ name.Mod.Child
 ## dot on special identifier
 
 __MODULE__.Child
-
-(source
-  (dot
-    (identifier)
-    (alias)))

--- a/test/support/corpus.ex
+++ b/test/support/corpus.ex
@@ -10,26 +10,58 @@ defmodule SourcerorTest.Support.Corpus do
   ]
 
   @doc """
-  Return paths to all Elixir files in the corpus.
+  Return paths to Elixir files in the corpus.
+
+  By default, all paths for syntax valid for the current system version
+  are returned. To include only some paths, pass a list of strings to be
+  compared using `=~`.
   """
-  def all_paths do
+  def paths(includes \\ [""]) do
     ommissions = ommissions()
 
     "test/corpus/**/*.ex"
     |> Path.wildcard()
     |> Enum.map(&Path.relative_to_cwd(&1))
-    |> Enum.reject(&omit?(ommissions, &1))
+    |> Enum.filter(&contains?(includes, &1))
+    |> Enum.reject(&contains?(ommissions, &1))
   end
 
-  def omit?(ommissions, file) do
+  defp contains?(ommissions, file) do
     Enum.any?(ommissions, &(file =~ &1))
   end
 
-  def ommissions do
+  defp ommissions do
     version = System.version()
 
     @version_requirements
     |> Enum.filter(fn {requirement, _file} -> not Version.match?(version, requirement) end)
     |> Enum.map(&elem(&1, 1))
+  end
+
+  @doc """
+  Applies the given function to every syntax node parsed from the included
+  paths.
+
+  See `paths/1` for how includes work.
+
+  The function must accept two arguments, the quoted node and the current
+  path, and is return value is ignored.
+  """
+  def walk!(includes \\ [""], fun) when is_list(includes) and is_function(fun, 2) do
+    includes
+    |> paths()
+    |> Enum.each(fn path ->
+      path
+      |> File.read!()
+      |> Sourceror.parse_string!()
+      |> walk(fun, path)
+    end)
+  end
+
+  defp walk(quoted, fun, path) do
+    Sourceror.prewalk(quoted, fn quoted, acc ->
+      fun.(quoted, path)
+      {quoted, acc}
+    end)
   end
 end


### PR DESCRIPTION
Implements the lower-level parts of #105.

This PR adds the following guards:

- `is_call/1`
- `is_unqualified_call/1`
- `is_qualified_call/1`
- `is_identifier/1`
- `is_atomic_literal/1`

Additional changes/fixes:

- Add the power operator (`**`) to the list of binary ops for Elixir 1.13+
- Refactor `SourcerorTest.Support.Corpus` somewhat to make its use a bit more ergonomic
- Remove a bit of leftover tree-sitter syntax from `test/corpus/term/alias.ex` (it wasn't erroring because S-expressions are also valid Elixir)

---

While working on this, I realized that these lower-level primitives might prove sufficient for the vast majority of cases. The higher-level things discussed in #105 are likely still useful, but I'd kind of like to kick the tires on these changes before introducing additional new API.