### PR TITLE
fix: negative range in String.slice/2

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -212,7 +212,7 @@ defmodule Sourceror do
       end)
 
     if is_list(quoted) and opts[:format] == :splicing do
-      text |> String.slice(1..-2)
+      text |> String.slice(1..-2//1)
     else
       text
     end


### PR DESCRIPTION
Elixir 1.16 requires a step when using a range with a start > stop in String.slice/2
