### PR TITLE
Fix get_range/1 for binaries

### DIFF
--- a/lib/sourceror/range.ex
+++ b/lib/sourceror/range.ex
@@ -91,7 +91,16 @@ defmodule Sourceror.Range do
       if meta[:delimiter] in [~S/"""/, ~S/'''/] do
         meta[:column] + String.length(meta[:delimiter])
       else
-        count = meta[:column] + String.length(last_line) + String.length(meta[:delimiter])
+        delimiter_count =
+          if String.contains?(string, meta[:delimiter]) do
+            ~r/#{meta[:delimiter]}/ |> Regex.scan(string) |> length()
+          else
+            0
+          end
+
+        count =
+          meta[:column] + String.length(last_line) + String.length(meta[:delimiter]) +
+            delimiter_count
 
         if end_line == meta[:line] do
           count + 1

--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -113,6 +113,9 @@ defmodule SourcerorTest.RangeTest do
       code = ~S/"fo\no"/
       assert decorate(code, to_range(code)) == "«\"fo\\no\"»"
 
+      code = ~S/"key: \"value\""/
+      assert decorate(code, to_range(code)) == "«\"key: \\\"value\\\"\"»"
+
       code = ~S'''
       """
       foo


### PR DESCRIPTION
Hi congrats on going `1.0.0`, that's always the big one.

I played around and found something:

It seems escaped double quotes are not counted in `Sourceror.get_range/1`:

```elixir
~S"""
# the following line is 16 chars long, so `end_column` should be 17
"key: \"value\""
"""
|> Sourceror.parse_string!()
|> Sourceror.get_range()
|> dbg
```

Let me know what you think of this :+1: