### PR TITLE
docs: fix formatting for get_range/2

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -655,15 +655,17 @@ defmodule Sourceror do
 
   ## Options
 
-        - `:include_comments` - When `true`, it includes the comments into the range. Defaults to `false`.
+  - `:include_comments` - When `true`, it includes the comments into the range. Defaults to `false`.
 
-        iex> ~S"\""
-        ...> # Foo
-        ...> :baz # Bar
-        ...> "\""
-        ...> |> Sourceror.parse_string!()
-        ...> |> Sourceror.get_range(include_comments: true)
-        %{start: [line: 1, column: 1], end: [line: 2, column: 11]}
+  ```elixir
+  iex> ~S"\""
+  ...> # Foo
+  ...> :baz # Bar
+  ...> "\""
+  ...> |> Sourceror.parse_string!()
+  ...> |> Sourceror.get_range(include_comments: true)
+  %{start: [line: 1, column: 1], end: [line: 2, column: 11]}
+  ```
   """
   @spec get_range(Macro.t()) :: range | nil
   def get_range(quoted, opts \\ []) do


### PR DESCRIPTION
Before: 

![CleanShot 2024-02-25 at 11 34 58@2x](https://github.com/doorgan/sourceror/assets/5523984/af75e9f8-c188-4957-a9d3-3b9743be15d5)

After:
![CleanShot 2024-02-25 at 11 35 11@2x](https://github.com/doorgan/sourceror/assets/5523984/56a653e6-9925-43fe-a099-e1326dc7dd78)
