### PR TITLE
Update README.md to remove 1.X notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ Updated](https://img.shields.io/github/last-commit/doorgan/sourceror.svg)](https
 
 Utilities to work with Elixir source code.
 
-**NOTICE:** This library is under heavy development. Expect frequent breaking
-changes until the first stable v1.0 release is out.
-
 ## Installation
 
 Add `:sourceror` as a dependency to your project's `mix.exs`:


### PR DESCRIPTION
1.X has been released, so there's no longer a need for the unstable API notice