### PR TITLE
Refactor formatting of leading comments

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -401,7 +401,14 @@ defmodule Sourceror do
       3
   """
   @spec get_line(Macro.t(), default :: integer | nil) :: integer | nil
-  def get_line({_, meta, _}, default \\ 1)
+  def get_line(quoted, default \\ 1)
+
+  def get_line({{:., _, [{:fn, _, _} = anonymous_fun | _]}, meta, _}, default)
+      when is_list(meta) and (is_integer(default) or is_nil(default)) do
+    get_line(anonymous_fun)
+  end
+
+  def get_line({_, meta, _}, default)
       when is_list(meta) and (is_integer(default) or is_nil(default)) do
     Keyword.get(meta, :line, default)
   end

--- a/lib/sourceror/comments.ex
+++ b/lib/sourceror/comments.ex
@@ -65,7 +65,10 @@ defmodule Sourceror.Comments do
   defp update_newlines({form, meta, args}, comments) do
     meta =
       if end_of_expression = Keyword.get(meta, :end_of_expression) do
-        newlines = end_of_expression[:newlines] - comments_in(comments, meta[:line] + 1, meta[:line] + end_of_expression[:newlines])
+        newlines =
+          end_of_expression[:newlines] -
+            comments_in(comments, meta[:line] + 1, meta[:line] + end_of_expression[:newlines])
+
         end_of_expression = Keyword.put(end_of_expression, :newlines, newlines)
         Keyword.put(meta, :end_of_expression, end_of_expression)
       else

--- a/lib/sourceror/lines_corrector.ex
+++ b/lib/sourceror/lines_corrector.ex
@@ -44,9 +44,13 @@ defmodule Sourceror.LinesCorrector do
       end
 
     if has_leading_comments?(quoted) do
-      leading_comments = length(meta[:leading_comments])
-      quoted = recursive_correct_lines(quoted, leading_comments + 1)
-      {quoted, %{state | last_line: meta[:line]}}
+      leading_comments =
+        Enum.reduce(meta[:leading_comments], 1, fn comment, acc ->
+          acc + comment.next_eol_count
+        end)
+
+      quoted = recursive_correct_lines(quoted, leading_comments)
+      {quoted, %{state | last_line: get_line(quoted)}}
     else
       {quoted, state}
     end

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -18,6 +18,20 @@ defmodule SourcerorTest do
       """)
     end
 
+    test "multiline comments" do
+      assert_same(~S"""
+      [
+        :field_1,
+
+        #######################################################
+        ### Another comment
+        #######################################################
+
+        :field_2
+      ]
+      """)
+    end
+
     test "blocks" do
       assert_same(~S"""
       foo()


### PR DESCRIPTION
closes #53 even if the title of the ticket mentioned trailing comments.

I have tried to take blank lines between and after comment to take into account. For that I have also updated the line corrector to get enough space for the leading comments.

