### PR TITLE
Refactor comment handling

### DIFF
--- a/lib/sourceror/lines_corrector.ex
+++ b/lib/sourceror/lines_corrector.ex
@@ -14,75 +14,104 @@ defmodule Sourceror.LinesCorrector do
   * If a node has a line number lower than the one before, its line number is
     recursively incremented by the line number difference, if it's not a
     pipeline operator.
-  * If a node has leading comments, it's line number is incremented by the
-    length of the comments list
-  * If a node has trailing comments, it's end_of_expression and end line
-    metadata are set to the line of their last child plus the trailing comments
-    list length
+  * If a node has leading comments, its line number is incremented by the
+    newlines for those comments.
+  * If a node has trailing comments, its end_of_expression and end line
+    metadata are set to the line of their last child plus the newlines of the
+    trailing comments list.
   """
   def correct(quoted) do
-    {ast, _} =
-      Macro.traverse(quoted, %{last_line: 1, last_form: nil}, &pre_correct/2, &post_correct/2)
+    case trailing_block(quoted) do
+      {:ok, block, line} ->
+        block
+        |> do_correct(line)
+        |> into_trailing_block(quoted)
 
-    ast
+      :error ->
+        do_correct(quoted, 1)
+    end
   end
 
-  defp pre_correct({form, meta, args} = quoted, state) do
-    {quoted, state} =
-      cond do
-        is_nil(meta[:line]) ->
-          meta = Keyword.put(meta, :line, state.last_line)
-          {{form, meta, args}, %{state | last_form: form}}
+  defp into_trailing_block(quoted, {:__block__, meta, [_]}) do
+    {:__block__, meta, [quoted]}
+  end
 
-        get_line(quoted) <= state.last_line and not is_binary_op(form) ->
-          correction = state.last_line - get_line(quoted)
-          quoted = recursive_correct_lines(quoted, correction)
-          {quoted, %{state | last_line: get_line(quoted), last_form: form}}
-
-        true ->
-          {quoted, %{state | last_form: form}}
-      end
-
-    if has_leading_comments?(quoted) do
-      leading_comments = length(meta[:leading_comments])
-      quoted = recursive_correct_lines(quoted, leading_comments + 1)
-      {quoted, %{state | last_line: meta[:line]}}
+  defp trailing_block({:__block__, meta, [quoted]}) do
+    if meta[:__sourceror__][:trailing_block] || false do
+      {:ok, quoted, comments_eol_count(meta[:leading_comments])}
     else
-      {quoted, state}
+      :error
     end
+  end
+
+  defp trailing_block(_quoted), do: :error
+
+  defp do_correct(quoted, line) do
+    quoted
+    |> Macro.traverse(%{last_line: line}, &pre_correct/2, &post_correct/2)
+    |> elem(0)
+  end
+
+  defp pre_correct({_form, _meta, _args} = quoted, state) do
+    do_pre_correct(quoted, state)
   end
 
   defp pre_correct(quoted, state) do
     {quoted, state}
   end
 
-  defp post_correct({_, meta, _} = quoted, state) do
-    quoted =
-      with {form, meta, [{_, _, _} = left, right]} when is_binary_op(form) <- quoted do
-        # We must ensure that, for binary operators, the operator line number is
-        # not greater than the left operand. Otherwise the comment eol counts
-        # will be ignored by the formatter
-        left_line = get_line(left)
+  defp do_pre_correct({:__block__, meta, [:do]}, state) do
+    state =
+      if meta[:format] != :keyword && meta[:line] == state.last_line,
+        do: %{state | last_line: state.last_line + 1},
+        else: state
 
-        if left_line > get_line(quoted) do
-          {form, Keyword.put(meta, :line, left_line), [left, right]}
-        else
-          quoted
-        end
-      end
+    {{:__block__, meta, [:do]}, state}
+  end
 
-    last_line = Sourceror.get_end_line(quoted, state.last_line)
+  defp do_pre_correct({form, meta, args} = quoted, state) do
+    case correction(form, meta[:line], meta[:leading_comments], state) do
+      nil ->
+        meta = Keyword.put(meta, :line, state.last_line)
+        {{form, meta, args}, state}
+
+      0 ->
+        {quoted, state}
+
+      correction ->
+        quoted = recursive_correct_lines(quoted, correction)
+        state = %{state | last_line: get_line(quoted)}
+        {quoted, state}
+    end
+  end
+
+  defp correction(_form, nil, _comments, _state), do: nil
+
+  defp correction(form, _line, _comments, _state) when is_binary_op(form), do: 0
+
+  defp correction(_form, line, comments, state) do
+    max(state.last_line + comments_eol_count(comments) - line, 0)
+  end
+
+  defp post_correct({_form, _meta, _args} = quoted, state) do
+    do_post_correct(quoted, state)
+  end
+
+  defp post_correct(quoted, state) do
+    {quoted, state}
+  end
+
+  defp do_post_correct({_, meta, _} = quoted, state) do
+    quoted = maybe_correct_binary_op(quoted)
 
     last_line =
       if has_trailing_comments?(quoted) do
-        if Sourceror.Identifier.do_block?(quoted) do
-          last_line + length(meta[:trailing_comments] || []) + 2
-        else
-          last_line + length(meta[:trailing_comments] || []) + 1
-        end
+        state.last_line + comments_eol_count(meta[:trailing_comments]) + 1
       else
-        last_line
+        state.last_line
       end
+
+    last_line = Sourceror.get_end_line(quoted, last_line)
 
     quoted =
       quoted
@@ -93,9 +122,21 @@ defmodule Sourceror.LinesCorrector do
     {quoted, %{state | last_line: last_line}}
   end
 
-  defp post_correct(quoted, state) do
-    {quoted, state}
+  defp maybe_correct_binary_op({form, meta, [{_, _, _} = left, right]} = quoted)
+       when is_binary_op(form) do
+    # We must ensure that, for binary operators, the operator line number is
+    # not greater than the left operand. Otherwise the comment eol counts
+    # will be ignored by the formatter
+    left_line = get_line(left)
+
+    if left_line > get_line(quoted) do
+      {form, Keyword.put(meta, :line, left_line), [left, right]}
+    else
+      quoted
+    end
   end
+
+  defp maybe_correct_binary_op(quoted), do: quoted
 
   defp maybe_correct_end_of_expression({form, meta, args} = quoted, last_line) do
     meta =
@@ -158,5 +199,20 @@ defmodule Sourceror.LinesCorrector do
       ast ->
         ast
     end)
+  end
+
+  defp comments_eol_count(comments, count \\ nil)
+
+  defp comments_eol_count(nil, _count), do: 0
+
+  defp comments_eol_count([], count), do: count || 0
+
+  defp comments_eol_count([comment | _] = comments, nil) do
+    line = comment.previous_eol_count - 1
+    comments_eol_count(comments, line)
+  end
+
+  defp comments_eol_count([comment | comments], lines) do
+    comments_eol_count(comments, lines + comment.next_eol_count)
   end
 end

--- a/lib/sourceror/lines_corrector.ex
+++ b/lib/sourceror/lines_corrector.ex
@@ -60,15 +60,6 @@ defmodule Sourceror.LinesCorrector do
     {quoted, state}
   end
 
-  defp do_pre_correct({:__block__, meta, [:do]}, state) do
-    state =
-      if meta[:format] != :keyword && meta[:line] == state.last_line,
-        do: %{state | last_line: state.last_line + 1},
-        else: state
-
-    {{:__block__, meta, [:do]}, state}
-  end
-
   defp do_pre_correct({form, meta, args} = quoted, state) do
     case correction(form, meta[:line], meta[:leading_comments], state) do
       nil ->

--- a/test/comments_test.exs
+++ b/test/comments_test.exs
@@ -2,6 +2,23 @@ defmodule SourcerorTest.CommentsTest do
   use ExUnit.Case, async: true
   doctest Sourceror.Comments
 
+  defmacrop assert_to_string(quoted, expected) do
+    quote bind_quoted: [quoted: quoted, expected: expected] do
+      expected_formatted = expected |> Code.format_string!([]) |> IO.iodata_to_binary()
+
+      if Version.match?(System.version(), "~> 1.16") do
+        assert expected == expected_formatted, """
+        The given expected code is not formatted.
+        Formatted code:
+        #{expected_formatted}
+        """
+      end
+
+      assert Sourceror.to_string(quoted, collapse_comments: true, correct_lines: true) ==
+               expected_formatted
+    end
+  end
+
   describe "merge_comments/2" do
     test "merges leading comments" do
       quoted =
@@ -125,8 +142,16 @@ defmodule SourcerorTest.CommentsTest do
       {_quoted, comments} = Sourceror.Comments.extract_comments(quoted, collapse_comments: true)
 
       assert [
-               %{line: 1, text: "# A"},
+               %{line: 0, text: "# A"},
                %{line: 1, text: "# B"}
+             ] = comments
+
+      {_quoted, comments} =
+        Sourceror.Comments.extract_comments(quoted, collapse_comments: true, correct_lines: true)
+
+      assert [
+               %{line: 1, text: "# A"},
+               %{line: 2, text: "# B"}
              ] = comments
 
       quoted =
@@ -140,9 +165,18 @@ defmodule SourcerorTest.CommentsTest do
       {_quoted, comments} =
         Sourceror.Comments.extract_comments(quoted, collapse_comments: true, correct_lines: true)
 
+      assert_to_string(quoted, """
+      def a do
+        :ok
+        # A
+      end
+
+      # B\
+      """)
+
       assert [
-               %{line: 5, text: "# A"},
-               %{line: 7, text: "# B"}
+               %{line: 3, text: "# A"},
+               %{line: 4, text: "# B"}
              ] = comments
 
       quoted =
@@ -156,22 +190,56 @@ defmodule SourcerorTest.CommentsTest do
       {_quoted, comments} =
         Sourceror.Comments.extract_comments(quoted, collapse_comments: true, correct_lines: true)
 
+      assert_to_string(quoted, """
+      Foo.{
+        A
+        # A
+      }
+
+      # B\
+      """)
+
       assert [
-               %{line: 5, text: "# A"},
-               %{line: 7, text: "# B"}
+               %{line: 3, text: "# A"},
+               %{line: 4, text: "# B"}
              ] = comments
 
-      assert Sourceror.to_string(quoted, collapse_comments: true, correct_lines: true) ==
-               """
-               Foo.{
-                 A
+      quoted =
+        Sourceror.parse_string!("""
+        Foo.{
+          A
+          # A
+          # B
+          # C
+        } # X
+        # Y
+        # Z
+        """)
 
-                 # A
-               }
+      {_quoted, comments} =
+        Sourceror.Comments.extract_comments(quoted, collapse_comments: true, correct_lines: true)
 
-               # B
-               """
-               |> String.trim()
+      assert_to_string(quoted, """
+      Foo.{
+        A
+        # A
+        # B
+        # C
+      }
+
+      # X
+      # Y
+      # Z\
+      """)
+
+      assert [
+               %{line: 3, text: "# A"},
+               %{line: 4, text: "# B"},
+               %{line: 5, text: "# C"},
+               %{line: 6, text: "# X"},
+               %{line: 7, text: "# Y"},
+               %{line: 8, text: "# Z"}
+             ] = comments
     end
   end
 end

--- a/test/lines_corrector_test.exs
+++ b/test/lines_corrector_test.exs
@@ -57,8 +57,8 @@ defmodule SourcerorTest.LinesCorrectorTest do
       assert {:foo, foo_meta, [[{_, {:bar, bar_meta, _}}]]} = corrected
 
       assert foo_meta[:line] == 1
-      assert bar_meta[:line] == 3
-      assert foo_meta[:end][:line] == 3
+      assert bar_meta[:line] == 5
+      assert foo_meta[:end][:line] == 5
 
       assert Sourceror.to_string(corrected) ==
                ~S"""

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -266,7 +266,7 @@ defmodule SourcerorTest do
       assert_same(code)
     end
 
-    test "xxx" do
+    test "with a :do in the args" do
       assert_same("""
       defp foo(state, {:do, :code}) do
         # Lorem ispum

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -265,6 +265,15 @@ defmodule SourcerorTest do
 
       assert_same(code)
     end
+
+    test "xxx" do
+      assert_same("""
+      defp foo(state, {:do, :code}) do
+        # Lorem ispum
+        state
+      end
+      """)
+    end
   end
 
   describe "parse_string!/2" do

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -2,14 +2,27 @@ defmodule SourcerorTest do
   use ExUnit.Case, async: true
   doctest Sourceror
 
-  defmacro assert_same(string, opts \\ []) do
+  defmacrop assert_same(string, opts \\ []) do
     quote bind_quoted: [string: string, opts: opts] do
-      string = String.trim(string)
-      assert string == Sourceror.parse_string!(string) |> Sourceror.to_string(opts)
+      formatted = string |> Code.format_string!([]) |> IO.iodata_to_binary()
+
+      if Version.match?(System.version(), "~> 1.16") do
+        assert formatted == String.trim(string), """
+        The given expected code is not formatted.
+        Formatted code:
+        #{formatted}
+        """
+      end
+
+      assert formatted == Sourceror.parse_string!(string) |> Sourceror.to_string(opts)
     end
   end
 
   describe "parse_string!/2 and to_string/2 comment position preservation" do
+    test "empty string" do
+      assert_same("")
+    end
+
     test "just some comments" do
       assert_same(~S"""
       # comment
@@ -180,9 +193,85 @@ defmodule SourcerorTest do
       def request(%S3{http_method: :head} = op), do: head_object(op)
       """)
     end
+
+    test "after expression" do
+      code = ~S"""
+      bar()
+      # test-comment
+      foo()
+      """
+
+      assert_same(code)
+    end
+
+    test "last line in def" do
+      code = ~S"""
+      def a_fun do
+        :return_value
+        # test-comment
+      end
+      """
+
+      assert_same(code)
+    end
+
+    test "in directly executed anonymous function" do
+      code = ~S"""
+      (fn x ->
+         # test-comment
+         x * x
+       end).()
+      """
+
+      assert_same(code)
+    end
+
+    test "multiple comment blocks" do
+      code = ~S"""
+      defmodule Z do
+        alias B
+        alias A
+
+        def a do
+          # test1
+          # test2
+          # line1
+          # line2
+          :ok
+        end
+
+        # test
+        defp z do
+          1
+        end
+      end
+      """
+
+      assert_same(code)
+    end
+
+    test "multiline comments in list" do
+      code = ~S"""
+      [
+        :field_1,
+
+        #######################################################
+        ### Another comment
+        #######################################################
+
+        :field_2
+      ]
+      """
+
+      assert_same(code)
+    end
   end
 
   describe "parse_string!/2" do
+    test "returns an empty block for an emtpy string" do
+      assert Sourceror.parse_string!("") == {:__block__, [], []}
+    end
+
     test "raises on invalid string" do
       assert_raise SyntaxError, fn ->
         Sourceror.parse_string!(":ok end")
@@ -375,10 +464,16 @@ defmodule SourcerorTest do
       code = """
       [
         1,
-      ]
+      ]\
       """
 
-      assert_same(code, quoted_to_algebra: quoted_to_algebra, trailing_comma: true)
+      assert code ==
+               code
+               |> Sourceror.parse_string!()
+               |> Sourceror.to_string(
+                 quoted_to_algebra: quoted_to_algebra,
+                 trailing_comma: true
+               )
     end
   end
 
@@ -620,7 +715,6 @@ defmodule SourcerorTest do
                ~S"""
                foo do
                  :ok
-
                  # B
                  # A
                end
@@ -643,7 +737,6 @@ defmodule SourcerorTest do
                ~S"""
                foo do
                  :ok
-
                  # B
                end
                """
@@ -662,7 +755,6 @@ defmodule SourcerorTest do
                ~S"""
                Foo.{
                  Bar
-
                  # B
                }
                """
@@ -753,7 +845,6 @@ defmodule SourcerorTest do
                ~S"""
                foo do
                  :ok
-
                  # B
                end
                """
@@ -772,7 +863,6 @@ defmodule SourcerorTest do
                ~S"""
                Foo.{
                  Bar
-
                  # B
                }
                """


### PR DESCRIPTION
closes #53 even if the title of the ticket mentioned trailing comments.

The PR refactors two things. The first refactoring changes the handling of trailing blocks. There are now some extra functions to handle the trailing blocks in separate functions. The AST inside the trailing block is always treated in the same way.

The other change concerns the line correction for leading and trailing comments. Then new version counts the newlines in the comments and not just the count of the comments.

The changes also make it necessary to adjust expected results in the tests. But I think that changes are making sense.