### PR TITLE
Map start position

### DIFF
--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -532,6 +532,9 @@ defmodule SourcerorTest do
 
       quoted = Sourceror.parse_string!("foo(:bar)")
       assert Sourceror.get_start_position(quoted) == [line: 1, column: 1]
+
+      quoted = Sourceror.parse_string!("%{a: 1}")
+      assert Sourceror.get_start_position(quoted) == [line: 1, column: 1]
     end
   end
 


### PR DESCRIPTION
Currently just a failing test as I'm not sure if this is by design or not. If there is some reason why maps start positions are not supposed to start at the `%` instead of the `{` let me know. If this is a bug I'm happy to look into the solution but just want to confirm this is infact a bug first.