### PR TITLE
Add Sourceror.Zipper.within/2

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -474,4 +474,15 @@ defmodule Sourceror.Zipper do
   @spec subtree(t) :: t
   @compile {:inline, subtree: 1}
   def subtree(%Z{} = zipper), do: %{zipper | path: nil}
+
+  @doc """
+  Runs the function `fun` on the subtree of the currently focused `node` and
+  returns the updated `zipper`.
+
+  `fun` must return a zipper, which may be positioned at the top of the subtree.
+  """
+  def within(%Z{} = zipper, fun) when is_function(fun, 1) do
+    updated = zipper |> subtree() |> fun.() |> top()
+    into(updated, zipper)
+  end
 end


### PR DESCRIPTION
Closes #134

Adds `Sourceror.Zipper.within/2` to streamline making modifications to a source tree. It follows @NickNeck suggestion of just adding `within/2` because `traverse/2` already works on a subtree
