### PR TITLE
Fix `get_range` for heredocs

### DIFF
--- a/lib/sourceror/range.ex
+++ b/lib/sourceror/range.ex
@@ -108,7 +108,9 @@ defmodule Sourceror.Range do
 
     end_column =
       if meta[:delimiter] in [~S/"""/, ~S/'''/] do
-        meta[:column] + String.length(meta[:delimiter])
+        delimiter_count = String.length(meta[:delimiter]) + 1
+        indentation = meta[:indentation] || 0
+        indentation + delimiter_count
       else
         delimiter_count =
           if String.contains?(string, meta[:delimiter]) do

--- a/test/range_test.exs
+++ b/test/range_test.exs
@@ -228,6 +228,33 @@ defmodule SourcerorTest.RangeTest do
                |> String.trim_trailing()
     end
 
+    test "heredocs" do
+      code = ~S'''
+      @moduledoc """
+      This is my funny moduledoc
+      """
+      '''
+
+      zipper =
+        code
+        |> Sourceror.parse_string!()
+        |> Sourceror.Zipper.zip()
+
+      heredoc =
+        zipper
+        |> Sourceror.Zipper.down()
+        |> Sourceror.Zipper.down()
+        |> Sourceror.Zipper.node()
+
+      assert decorate(code, Sourceror.get_range(heredoc)) ==
+               ~S'''
+               @moduledoc «"""
+               This is my funny moduledoc
+               """»
+               '''
+               |> String.trim_trailing()
+    end
+
     test "charlists" do
       code = ~S/'foo'/
       assert decorate(code, to_range(code)) == "«'foo'»"


### PR DESCRIPTION
The ranges for AST for code like

```elixir
@moduledoc """
This is my funny moduledoc
"""
```

Was returning incorrect values because it wasn't counting the `\n` at the end of the string
