### PR TITLE
improvement: add move_to_cursor/2

### DIFF
--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -739,4 +739,81 @@ defmodule SourcerorTest.ZipperTest do
              """
     end
   end
+
+  describe "move_to_cursor/2" do
+    test "if the cursor is top level, it matches everything" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      ___cursor___
+      """
+
+      assert code == Z.move_to_cursor(code, seek)
+    end
+
+    test "if the cursor is inside of a block" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      if foo == :bar do
+        ___cursor___
+      end
+      """
+
+      assert new_zipper = Z.move_to_cursor(code, seek)
+
+      assert "IO.puts(\"Hello\")" == new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
+    end
+
+    test "a really complicated example" do
+      code =
+        """
+        defmodule Foo do
+          @foo File.read!("foo.txt")
+
+          case @foo do
+            "foo" ->
+              10
+
+            "bar" ->
+              20
+          end
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      defmodule Foo do
+        @foo File.read!("foo.txt")
+
+        case @foo do
+          "foo" ->
+            10
+
+          "bar" ->
+            ___cursor___
+        end
+      end
+      """
+
+      assert new_zipper = Z.move_to_cursor(code, seek)
+
+      assert "20" == new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
+    end
+  end
 end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -803,8 +803,8 @@ defmodule SourcerorTest.ZipperTest do
         @foo File.read!("foo.txt")
 
         case @foo do
-          "foo" ->
-            10
+          __ ->
+            __
 
           "bar" ->
             __cursor__()

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -752,7 +752,7 @@ defmodule SourcerorTest.ZipperTest do
         |> Z.zip()
 
       seek = """
-      ___cursor___
+      __cursor__()
       """
 
       assert code == Z.move_to_cursor(code, seek)
@@ -770,13 +770,14 @@ defmodule SourcerorTest.ZipperTest do
 
       seek = """
       if foo == :bar do
-        ___cursor___
+        __cursor__()
       end
       """
 
       assert new_zipper = Z.move_to_cursor(code, seek)
 
-      assert "IO.puts(\"Hello\")" == new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
+      assert "IO.puts(\"Hello\")" ==
+               new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
     end
 
     test "a really complicated example" do
@@ -806,7 +807,7 @@ defmodule SourcerorTest.ZipperTest do
             10
 
           "bar" ->
-            ___cursor___
+            __cursor__()
         end
       end
       """


### PR DESCRIPTION
So, I'm sure that there will need to be lots of workshopping or even that the implementation should be fully changed, but this at a minimum starts the conversation :)

Its relatively simple, but does technically break if someone is using the variables/functions `___cursor___` or `___skip___` (note the triple underscores).