### PR TITLE
Add `Zipper.search_pattern/2`

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -589,9 +589,9 @@ defmodule Sourceror.Zipper do
     do_find(zipper, move(direction), predicate)
   end
 
-  def do_find(nil, _move, _predicate), do: nil
+  defp do_find(nil, _move, _predicate), do: nil
 
-  def do_find(%Z{node: tree} = zipper, move, predicate) do
+  defp do_find(%Z{node: tree} = zipper, move, predicate) do
     if predicate.(tree) do
       zipper
     else

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -740,6 +740,94 @@ defmodule SourcerorTest.ZipperTest do
     end
   end
 
+  describe "search_pattern/2 with cursor" do
+    test "matches everything at top level" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      __cursor__()
+      """
+
+      assert code == Z.search_pattern(code, seek)
+    end
+
+    test "matches sub-expression with cursor" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      IO.puts(__cursor__())
+      """
+
+      assert ~S["Hello"] ==
+               code |> Z.search_pattern(seek) |> Z.node() |> Sourceror.to_string()
+    end
+
+    test "matches sub-expression with cursor and ignored elements" do
+      code =
+        """
+        if foo == :bar do
+          "Hello" |> IO.puts()
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = """
+      __ |> __cursor__()
+      """
+
+      assert "IO.puts()" ==
+               code |> Z.search_pattern(seek) |> Z.node() |> Sourceror.to_string()
+    end
+  end
+
+  describe "search_pattern/2 without cursor" do
+    test "matches everything when pattern is exact match" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = ~S[if(foo == :bar, do: IO.puts("Hello"))]
+
+      assert code == Z.search_pattern(code, seek)
+    end
+
+    test "matches sub-expression" do
+      code =
+        """
+        if foo == :bar do
+          IO.puts("Hello")
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Z.zip()
+
+      seek = ~S[IO.puts("Hello")]
+
+      assert ~S[IO.puts("Hello")] ==
+               code |> Z.search_pattern(seek) |> Z.node() |> Sourceror.to_string()
+    end
+  end
+
   describe "move_to_cursor/2" do
     test "if the cursor is top level, it matches everything" do
       code =

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -777,7 +777,7 @@ defmodule SourcerorTest.ZipperTest do
       assert new_zipper = Z.move_to_cursor(code, seek)
 
       assert "IO.puts(\"Hello\")" ==
-               new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
+               new_zipper |> Z.node() |> Sourceror.to_string()
     end
 
     test "a really complicated example" do
@@ -814,7 +814,7 @@ defmodule SourcerorTest.ZipperTest do
 
       assert new_zipper = Z.move_to_cursor(code, seek)
 
-      assert "20" == new_zipper |> Z.subtree() |> Z.node() |> Sourceror.to_string()
+      assert "20" == new_zipper |> Z.node() |> Sourceror.to_string()
     end
   end
 end


### PR DESCRIPTION
Expanding on #147 which introduced `Zipper.move_to_cursor/2`, this PR adds a more general `Zipper.search_pattern/2`, which can match an arbitrarily nested pattern.

Also included is a small fix that makes `do_find` private (it was accidentally exposed) and a refactor for `move_to_cursor`.

cc @zachdaniel, @NickNeck 