### PR TITLE
improvement: allow modifications of `supertree` in `Zipper.within/2`

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -745,6 +745,6 @@ defmodule Sourceror.Zipper do
   """
   def within(%Z{} = zipper, fun) when is_function(fun, 1) do
     updated = zipper |> subtree() |> fun.() |> top()
-    into(updated, zipper)
+    into(updated, updated.supertree || zipper)
   end
 end


### PR DESCRIPTION
We have our own version of `within/2` in igniter for unrelated reasons, but I thought this improvement might be welcome.

We have a situation where we want to both:

1. preserve the original location
2. modify the "surrounding code".

By using the returned zipper's `supertree` (if present), we allow this kind of modification.