### PR TITLE
Fix for strip_meta/1

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -903,6 +903,7 @@ defmodule Sourceror do
       {name, _meta, args}, acc -> {{name, {}, args}, acc}
       other, acc -> {other, acc}
     end)
+    |> elem(0)
   end
 
   defp do_patch_string(lines, [], seen, _), do: Enum.reverse(lines) ++ seen

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -1238,9 +1238,9 @@ defmodule SourcerorTest do
       quoted = Sourceror.parse_string!(original)
 
       assert Sourceror.strip_meta(quoted) == {
-               {:hello, {},
-                [{:world, {}, nil}, [{{:__block__, {}, [:do]}, {:__block__, {}, [:ok]}}]]},
-               []
+               :hello,
+               {},
+               [{:world, {}, nil}, [{{:__block__, {}, [:do]}, {:__block__, {}, [:ok]}}]]
              }
     end
   end


### PR DESCRIPTION
The result of `Macro.prewalk` shouldn't be retured, the AST should be