### PR TITLE
Add `Zipper.within_range/2`

### DIFF
--- a/test/support/cursor_support.ex
+++ b/test/support/cursor_support.ex
@@ -32,7 +32,7 @@ defmodule SourcerorTest.CursorSupport do
       start_line = length(lines_before)
       end_line = start_line + length(range_lines) - 1
 
-      start_column = String.length(last_before_line)
+      start_column = String.length(last_before_line) + 1
       end_column = range_lines |> List.last() |> String.length()
 
       end_column =
@@ -44,7 +44,7 @@ defmodule SourcerorTest.CursorSupport do
 
       range = %Sourceror.Range{
         start: [line: start_line, column: start_column],
-        end: [line: end_line, column: end_column + 1]
+        end: [line: end_line, column: end_column]
       }
 
       text = before_text <> range_text <> after_text

--- a/test/support/cursor_support.ex
+++ b/test/support/cursor_support.ex
@@ -18,4 +18,40 @@ defmodule SourcerorTest.CursorSupport do
         raise ArgumentError, "Could not find cursor in:\n\n#{text}"
     end
   end
+
+  @doc """
+  Extracts a `Sourceror.Range` from the text enclosed in `«` and `»` characters.
+  """
+  def pop_range(text) do
+    with [before_text, after_text] <- String.split(text, "«", parts: 2),
+         [range_text, after_text] <- String.split(after_text, "»", parts: 2) do
+      lines_before = String.split(before_text, "\n")
+      range_lines = String.split(range_text, "\n")
+      last_before_line = lines_before |> List.last()
+
+      start_line = length(lines_before)
+      end_line = start_line + length(range_lines) - 1
+
+      start_column = String.length(last_before_line)
+      end_column = range_lines |> List.last() |> String.length()
+
+      end_column =
+        if last_before_line == "" do
+          end_column
+        else
+          end_column + start_column
+        end
+
+      range = %Sourceror.Range{
+        start: [line: start_line, column: start_column],
+        end: [line: end_line, column: end_column + 1]
+      }
+
+      text = before_text <> range_text <> after_text
+
+      {range, text}
+    else
+      _ -> raise ArgumentError, "Could not find range in:\n\n#{text}"
+    end
+  end
 end


### PR DESCRIPTION
Adds a new `within_range/2` function to `Sourceror.Zipper` that creates a zipper at the innermost node within a given range.

There is some trickier cases like `Foo.«bar»(42)` where we'd like to target the zipper at `bar`, however `bar` there is not a 3-tuple, normal node in elixir AST, so that will return an empty range...