### PR TITLE
gp-pereira/zipper_at_range

### DIFF
--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -152,6 +152,53 @@ defmodule Sourceror.Zipper do
   end
 
   @doc """
+  Walks the `zipper` to the innermost node that contains the
+  `range` or to the first node that perfectly matches it.
+
+  Returns `nil` if the `range` is not contained in the `zipper`.
+
+  Modifying `zipper` prior to using `at_range/2` is not recommended as added or changed
+  descendants may not contain accurate position metadata used to find the focus.
+  """
+  @spec at_range(t, Sourceror.Range.t()) :: t | nil
+  def at_range(zipper, %Sourceror.Range{} = range) do
+    zipper
+    |> Z.traverse_while(nil, fn
+      %{node: node} = zipper, acc ->
+        node_range = Sourceror.get_range(node)
+
+        cond do
+          is_nil(node_range) ->
+            {:cont, zipper, acc}
+
+          # range ends before node start
+          # halting to avoid unnecessary traversals
+          Sourceror.compare_positions(range.end, node_range.start) == :lt ->
+            {:halt, zipper, acc}
+
+          # range starts before node start
+          Sourceror.compare_positions(range.start, node_range.start) == :lt ->
+            {:cont, zipper, acc}
+
+          # range ends after node end
+          Sourceror.compare_positions(range.end, node_range.end) == :gt ->
+            {:cont, zipper, acc}
+
+          # range is the same as parent's so they are the "same"
+          # (you may comment this and take look at the broken test)
+          not is_nil(acc) and is_tuple(acc.node) and
+              Sourceror.get_range(acc.node) == node_range ->
+            {:cont, zipper, acc}
+
+          # range is inside node
+          true ->
+            {:cont, zipper, zipper}
+        end
+    end)
+    |> elem(1)
+  end
+
+  @doc """
   Walks the `zipper` to the top of the current subtree and returns that `zipper`.
   """
   @spec top(t) :: t

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -176,6 +176,11 @@ defmodule Sourceror.Zipper do
           Sourceror.compare_positions(range.end, node_range.start) == :lt ->
             {:halt, zipper, acc}
 
+          # range starts after node end
+          # no need to traverse node's children
+          Sourceror.compare_positions(range.start, node_range.end) == :gt ->
+            {:skip, zipper, acc}
+
           # range starts before node start
           Sourceror.compare_positions(range.start, node_range.start) == :lt ->
             {:cont, zipper, acc}

--- a/lib/sourceror/zipper.ex
+++ b/lib/sourceror/zipper.ex
@@ -161,6 +161,7 @@ defmodule Sourceror.Zipper do
   descendants may not contain accurate position metadata used to find the focus.
   """
   @spec at_range(t, Sourceror.Range.t()) :: t | nil
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def at_range(zipper, %Sourceror.Range{} = range) do
     zipper
     |> Z.traverse_while(nil, fn

--- a/test/support/cursor_support.ex
+++ b/test/support/cursor_support.ex
@@ -18,4 +18,40 @@ defmodule SourcerorTest.CursorSupport do
         raise ArgumentError, "Could not find cursor in:\n\n#{text}"
     end
   end
+
+  @doc """
+  Extracts a `Sourceror.Range` from the text enclosed in `«` and `»` characters.
+  """
+  def pop_range(text) do
+    with [before_text, after_text] <- String.split(text, "«", parts: 2),
+         [range_text, after_text] <- String.split(after_text, "»", parts: 2) do
+      lines_before = String.split(before_text, "\n")
+      range_lines = String.split(range_text, "\n")
+
+      start_line = length(lines_before)
+      end_line = start_line + length(range_lines) - 1
+
+      last_before_line = lines_before |> List.last()
+      start_column = last_before_line |> String.length()
+      end_column = range_lines |> List.last() |> String.length()
+
+      end_column =
+        if last_before_line != "" and start_line == end_line do
+          end_column + start_column
+        else
+          end_column
+        end
+
+      range = %Sourceror.Range{
+        start: [line: start_line, column: start_column + 1],
+        end: [line: end_line, column: end_column]
+      }
+
+      text = before_text <> range_text <> after_text
+
+      {range, text}
+    else
+      _ -> raise ArgumentError, "Could not find range in:\n\n#{text}"
+    end
+  end
 end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -2,7 +2,7 @@ defmodule SourcerorTest.ZipperTest do
   use ExUnit.Case, async: true
   doctest Sourceror.Zipper, import: true
 
-  import SourcerorTest.CursorSupport, only: [pop_cursor: 1]
+  import SourcerorTest.CursorSupport, only: [pop_cursor: 1, pop_range: 1]
 
   alias Sourceror.Zipper, as: Z
 
@@ -1229,6 +1229,174 @@ defmodule SourcerorTest.ZipperTest do
                def foo do
                  [1, 2, 3, 4, 5]
                end|
+               """)
+    end
+  end
+
+  describe "at_range/2" do
+    defp zipper_at_range(code_with_range) do
+      {range, code} = pop_range(code_with_range)
+      code |> Sourceror.parse_string!() |> Z.zip() |> Z.at_range(range)
+    end
+
+    test "creates a zipper focused on an inner literal equal to the given range" do
+      assert %{node: {:__block__, _, [2]}} =
+               zipper_at_range("""
+               def foo do
+                 [1, «2», 3, 4, 5]
+               end
+               """)
+    end
+
+    test "creates a zipper focused on the last container node if multiple siblings match" do
+      assert %{
+               node: [
+                 {:__block__, _, [1]},
+                 {:__block__, _, [2]},
+                 {:__block__, _, [3]},
+                 {:__block__, _, [4]},
+                 {:__block__, _, [5]}
+               ]
+             } =
+               zipper_at_range("""
+               def foo do
+                 [1, «2, 3», 4, 5]
+               end
+               """)
+    end
+
+    test "creates a zipper focused on the last container node even if range is not a real node" do
+      assert %{node: {:foo, _, [{:arg, _, nil}]}} =
+               zipper_at_range("""
+               def «foo»(arg) do
+                 arg
+               end
+               """)
+    end
+
+    test "creates a zipper focused on an alias segment" do
+      assert %{node: {:__aliases__, _, [:Baz]}} =
+               zipper_at_range("""
+               alias Foo.{Bar, «Baz»}
+               """)
+    end
+
+    test "creates a zipper focused on an alias group" do
+      assert %{
+               node:
+                 {{:., _, [{_, _, [:Foo]}, :{}]}, _,
+                  [
+                    {:__aliases__, _, [:Bar]},
+                    {:__aliases__, _, [:Baz]}
+                  ]}
+             } =
+               zipper_at_range("""
+               alias Foo.«{Bar, Baz}»
+               """)
+    end
+
+    test "creates a zipper focused on the whole alias" do
+      assert %{node: {:alias, _, _}} =
+               zipper_at_range("""
+               «alias» Foo.{Bar, Baz}
+               """)
+    end
+
+    test "creates a zipper focused on the last container node for a multiline range" do
+      assert %{node: {:fn, _, _}} =
+               zipper_at_range("""
+               Enum.map(filenames, fn «f ->
+                 f <> ".txt"
+               end»)
+               """)
+    end
+
+    test "creates a zipper focused on a function call name" do
+      assert %{node: {:bar, _, [_, _, _]}} =
+               zipper_at_range("""
+               def foo do
+                 «bar»(1, 2, 3)
+               end
+               """)
+    end
+
+    test "creates a zipper focused on a qualified call when the range covers the call name" do
+      assert %{node: {:., _, [{:__aliases__, _, [:Foo]}, :bar]}} =
+               zipper_at_range("""
+               def foo do
+                 Foo.«bar»(1, 2, 3)
+               end
+               """)
+    end
+
+    test "creates a zipper focused on a qualified call alias when the range covers the alias" do
+      assert %{node: {:__aliases__, _, [:Foo]}} =
+               zipper_at_range("""
+               def foo do
+                 «Foo».bar(1, 2, 3)
+               end
+               """)
+    end
+
+    test "creates a zipper focused on the whole qualified call" do
+      assert %{node: {:., _, [{:__aliases__, _, [:Foo]}, :bar]}} =
+               zipper_at_range("""
+               def foo do
+                 «Foo.bar»(1, 2, 3)
+               end
+               """)
+    end
+
+    test "creates a zipper focused on a qualified call suffix" do
+      assert %{node: {:., _, [{:baz, _, _}, :bar]}} =
+               zipper_at_range("""
+               def foo do
+                 «baz.bar»(1, 2, 3)
+               end
+               """)
+    end
+
+    test "creates a zipper focused on a map key usage" do
+      assert %{node: {{:., _, [{:baz, _, _}, :bar]}, _, []}} =
+               zipper_at_range("""
+               def foo do
+                 «baz.bar»
+               end
+               """)
+    end
+
+    test "creates a zipper focused on the entire qualified call" do
+      assert %{node: {{:., _, [{:__aliases__, _, [:Foo]}, :baz]}, _, [_, _, _]}} =
+               zipper_at_range("""
+               def foo do
+                 «Foo.baz(1, 2, 3)»
+               end
+               """)
+    end
+
+    test "creates a zipper focused on an operand of a binary operator" do
+      assert %{node: {:__block__, _, [2]}} =
+               zipper_at_range("""
+               def foo do
+                 1 + «2»
+               end
+               """)
+
+      assert %{node: {:__block__, _, [1]}} =
+               zipper_at_range("""
+               def foo do
+                 «1» + 2
+               end
+               """)
+    end
+
+    test "returns nil if there is no node that contains the range" do
+      assert nil ==
+               zipper_at_range("""
+               def foo(arg) do
+                 arg
+               end
+               « »
                """)
     end
   end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -1390,6 +1390,21 @@ defmodule SourcerorTest.ZipperTest do
                """)
     end
 
+    test "creates a zipper focused on the second function header" do
+      assert %{node: {:bar, _, nil}} =
+               zipper_at_range("""
+               defmodule Foo do
+                 def foo do
+                   1 + 2
+                 end
+
+                 def «bar» do
+                   1 + 2
+                 end
+               end
+               """)
+    end
+
     test "returns nil if there is no node that contains the range" do
       assert nil ==
                zipper_at_range("""


### PR DESCRIPTION
Adds a new `at_range/2` function to `Sourceror.Zipper` that walks a zipper to the innermost node that contains a given `Sourceror.Range` or to the first node to perfectly match it.

This PR takes the opposite approach from #185, solving the issues around ranges that are not real nodes. For instance, `Foo.«bar»(42)` would take the zipper to `%{node: {:., _, [{:__aliases__, _, [:Foo]}, :bar]}}`, which is not perfect but a good enough start to work around this range. 
