### PR TITLE
fix: clear all sourceror compilation warnings

### DIFF
--- a/lib/sourceror/code/keyword.ex
+++ b/lib/sourceror/code/keyword.ex
@@ -15,7 +15,6 @@ defmodule Sourceror.Code.Keyword do
   @moduledoc """
   Utilities for working with keyword.
   """
-  require Sourceror.Code.Common
   alias Sourceror.Code.Common
   alias Sourceror.Zipper
 
@@ -154,7 +153,6 @@ defmodule Sourceror.Code.Keyword do
       else
         {:new, zipper} -> {:ok, set_keyword_value!(zipper, value)}
         :error -> :error
-        {:ok, _} = other -> other
       end
     end)
   end

--- a/lib/sourceror/fast_zipper.ex
+++ b/lib/sourceror/fast_zipper.ex
@@ -859,8 +859,6 @@ defmodule Sourceror.FastZipper do
   end
 
   @compile {:inline, into: 2}
-  defp into(zipper, nil), do: zipper
-
   defp into(zipper(path: nil) = zipper, zipper(path: path, supertree: supertree)),
     do: zipper(zipper, path: path, supertree: supertree)
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,13 +17,35 @@ defmodule Sourceror.MixProject do
       docs: docs(),
       package: package(),
       dialyzer: dialyzer(),
-      test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test
-      ]
+      test_coverage: [tool: ExCoveralls]
+    ]
+    |> maybe_add_preferred_cli_env()
+  end
+
+  # `:preferred_cli_env` in `def project` is deprecated since Elixir v1.19
+  # in favor of `def cli` with `:preferred_envs`. `def cli` is available
+  # from Elixir v1.14 onwards, so on v1.12/v1.13 we still set the legacy
+  # option in `def project` to avoid breaking the build.
+  defp maybe_add_preferred_cli_env(project) do
+    if Version.match?(System.version(), "< 1.14.0") do
+      Keyword.put(project, :preferred_cli_env, preferred_envs())
+    else
+      project
+    end
+  end
+
+  if Version.match?(System.version(), ">= 1.14.0") do
+    def cli do
+      [preferred_envs: preferred_envs()]
+    end
+  end
+
+  defp preferred_envs do
+    [
+      coveralls: :test,
+      "coveralls.detail": :test,
+      "coveralls.post": :test,
+      "coveralls.html": :test
     ]
   end
 


### PR DESCRIPTION
## Summary

`mix compile` emitted four warnings for sourceror itself (excluding warnings from dev/test dependencies). This PR resolves all of them.

## Changes

**`mix.exs`** — Move `:preferred_cli_env` from `def project` to a new `def cli` callback (renamed `:preferred_envs`). Fixes the Mix 1.20 deprecation warning.

**`lib/sourceror/code/keyword.ex`**
- Drop unused `require Sourceror.Code.Common`. The file only uses `Common` via `alias` for regular function calls; no macros are invoked.
- Remove the unreachable `{:ok, _} = other -> other` clause in `set_keyword_key/4`'s `with` else block. The `with` already matches `{:ok, _}` from the updater, so this else branch can never receive an `{:ok, _}` value.

**`lib/sourceror/fast_zipper.ex`**
- Remove the unreachable `defp into(zipper, nil), do: zipper` clause. None of the 6 call sites of `into/2` ever pass `nil` as the second argument (the only caller that *might* — `topmost/1` — is guarded with `when not is_nil(supertree)`).

## Verification

```
$ mix compile
Compiling 20 files (.ex)
Generated sourceror app

$ mix compile --warnings-as-errors
Compiling 20 files (.ex)
Generated sourceror app

$ MIX_ENV=test mix compile
Compiling 24 files (.ex)
Generated sourceror app
```

Existing tests still pass (499/500, the single failure at `test/sourceror_test.exs:307` is a pre-existing assertion on parser metadata unrelated to these changes — verified by running the test against unmodified `HEAD`).
