### PR TITLE
fix: make get_start_position return the default for nodes without metadata

### DIFF
--- a/lib/sourceror.ex
+++ b/lib/sourceror.ex
@@ -616,6 +616,8 @@ defmodule Sourceror do
     Keyword.merge(default, position)
   end
 
+  def get_start_position(_, default), do: default
+
   @doc """
   Returns the end position of the quoted expression. It recursively checks for
   `end`, `closing` and `end_of_expression` positions. If none is found, the

--- a/test/sourceror_test.exs
+++ b/test/sourceror_test.exs
@@ -665,6 +665,10 @@ defmodule SourcerorTest do
       quoted = Sourceror.parse_string!("%{a: 1}")
       assert Sourceror.get_start_position(quoted) == [line: 1, column: 1]
     end
+
+    test "returns the default as a fallback" do
+      assert Sourceror.get_start_position(:erlang, line: 1, column: 2) == [line: 1, column: 2]
+    end
   end
 
   describe "get_end_position/2" do


### PR DESCRIPTION
Fixes issue reported at https://github.com/expert-lsp/expert/issues/724